### PR TITLE
[FIX] Use composer_options to check install

### DIFF
--- a/deployer/deploy/task/deploy_check_composer_install.php
+++ b/deployer/deploy/task/deploy_check_composer_install.php
@@ -7,7 +7,7 @@ use Deployer\Exception\GracefulShutdownException;
 // Read more on https://github.com/sourcebroker/deployer-extended#deploy-check-composer-install
 task('deploy:check_composer_install', function () {
     if (file_exists(get('current_dir') . '/composer.lock')) {
-        $output = runLocally('{{local/bin/composer}} --ignore-platform-reqs install --dry-run 2>&1');
+        $output = runLocally('{{local/bin/composer}} install {{composer_options}} --dry-run 2>&1');
         if (strpos($output, 'Nothing to install') === false && strpos($output,
                 'Package operations: 0 installs, 0 updates, 0 removals') === false) {
             throw new GracefulShutdownException('A composer.lock changes has been detected but you did not run "composer install". Please run composer install, then check if everything is working on your instance and do deploy after.');


### PR DESCRIPTION
Utilise the global `composer_options` to check the composer install - as this is what is running on `deploy:vendors`

I ran into a situation where I had a `require-dev` dependnecy. My deployment pipeline runs `--no-dev`, along with the `deploy:vendors`, however the deployment failed as the `deploy:check_composer_install` wanted the dev dependencies to be there