### PR TITLE
[TASK][FEATURE] Print http status code for curl in cache:clear_php_http

### DIFF
--- a/deployer/cache/task/cache_clear_php_http.php
+++ b/deployer/cache/task/cache_clear_php_http.php
@@ -43,7 +43,7 @@ task('cache:clear_php_http', function () {
         case 'curl':
             runLocally(
                 '{{local/bin/curl}} ' . get('fetch_method_curl_options',
-                    '--insecure --silent --location') . ' ' . escapeshellarg($clearCacheUrl) . ' > /dev/null',
+                    '--insecure --silent --location --output /dev/null --write "%{http_code}"') . ' ' . escapeshellarg($clearCacheUrl) . ' 2>/dev/null',
                 ['timeout', get('cache:clear_php_http:timeout', 15)]
             );
             break;


### PR DESCRIPTION
The previous options suppressed all output, what makes debugging more difficult if the url is not accessible for any reason. Printing the status code will provide the ability to detect that.