### PR TITLE
(fix): escape binarypath to handle paths with spaces

### DIFF
--- a/deployer/set.php
+++ b/deployer/set.php
@@ -132,7 +132,7 @@ function locateLocalBinaryPath($name): string
     $path = runLocally("command -v $nameEscaped || which $nameEscaped || type -p $nameEscaped");
     if ($path) {
         // Deal with issue when `type -p` outputs something like `type -ap` in some implementations
-        return trim(str_replace("$name is", "", $path));
+        return escapeshellarg(trim(str_replace("$name is", "", $path)));
     }
     throw new GracefulShutdownException("Can't locate [$nameEscaped] - neither of [command|which|type] commands are available");
 }


### PR DESCRIPTION
Local binary paths can contain spaces (e.g. `/Users/name/Library/Application Support/Herd/bin/composer`) which breaks among others things the composer_validate check

> task deploy:check_composer_validate
> [server] error in deploy_check_composer_validate.php on line 13:
> [server] run export DO_NOT_TRACK='true' DO_NOT_SHOW_BANNER='true'; /Users/name/Library/Application Support/Herd/bin/composer validate --no-check-all --no-check-publish
> [server] err bash: line 1: /Users/name/Library/Application: No such file or directory
> [server] exit code 127 (Command not found)
> ERROR: Task deploy:check_composer_validate failed!