### PR TITLE
[BUGFIX] Correct curl flag in cache clear command

### DIFF
--- a/deployer/cache/task/cache_clear_php_http.php
+++ b/deployer/cache/task/cache_clear_php_http.php
@@ -43,7 +43,7 @@ task('cache:clear_php_http', function () {
         case 'curl':
             runLocally(
                 '{{local/bin/curl}} ' . get('fetch_method_curl_options',
-                    '--insecure --silent --location --output /dev/null --write "%{http_code}"') . ' ' . escapeshellarg($clearCacheUrl) . ' 2>/dev/null',
+                    '--insecure --silent --location --output /dev/null --write-out "%{http_code}"') . ' ' . escapeshellarg($clearCacheUrl) . ' 2>/dev/null',
                 ['timeout', get('cache:clear_php_http:timeout', 15)]
             );
             break;


### PR DESCRIPTION
The `--write` flag doesn't exist in curl. Changed to `--write-out` to properly output HTTP status code.